### PR TITLE
fix: disable no-useless-constructor in favor of @typescript-eslint/no-useless-constructor

### DIFF
--- a/configs/@typescript-eslint/index.js
+++ b/configs/@typescript-eslint/index.js
@@ -24,5 +24,6 @@ module.exports = {
   "@typescript-eslint/no-var-requires": ["error"],
   "@typescript-eslint/prefer-namespace-keyword": ["error"],
   "@typescript-eslint/triple-slash-reference": ["error"],
-  "@typescript-eslint/type-annotation-spacing": ["error"]
+  "@typescript-eslint/type-annotation-spacing": ["error"],
+  "@typescript-eslint/no-useless-constructor": ["error"]
 };

--- a/configs/eslint/index.js
+++ b/configs/eslint/index.js
@@ -169,7 +169,7 @@ module.exports = {
   ],
   "no-this-before-super": ["error"],
   "no-useless-computed-key": ["error"],
-  "no-useless-constructor": ["error"],
+  "no-useless-constructor": ["off"],
   "no-useless-rename": [
     "error",
     {


### PR DESCRIPTION
ESLint Rule 'no-useless-constructor' conflicts with rule '@typescript-eslint/no-useless-constructor'. 
So disable Eslint rule and enable @typescript-eslint rule.