### PR TITLE
fix(import/extensions): add broken typescript support

### DIFF
--- a/configs/import/index.js
+++ b/configs/import/index.js
@@ -54,8 +54,9 @@ module.exports = {
     "ignorePackages",
     {
       js: "never",
-      mjs: "never",
-      jsx: "never"
+      jsx: "never",
+      ts: "never",
+      tsx: "never"
     }
   ],
   "import/order": [

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
   settings: {
     "import/resolver": {
       node: {
-        extensions: [".ts", ".tsx"]
+        extensions: [".js", ".jsx", ".ts", ".tsx"]
       }
     },
     react: {
@@ -40,7 +40,7 @@ module.exports = {
       version: "detect"
     },
     propWrapperFunctions: ["forbidExtraProps", "exact", "Object.freeze"],
-    "import/extensions": [".js", ".mjs", ".jsx", ".ts", ".tsx"],
+    "import/extensions": [".js", ".jsx", ".ts", ".tsx"],
     "import/core-modules": [],
     "import/ignore": ["node_modules", "\\.(coffee|scss|css|less|hbs|svg|json)$"]
   },


### PR DESCRIPTION
Addresses the issue with upgrade to 2.20 as in here: https://github.com/benmosher/eslint-plugin-import/issues/1615