### PR TITLE
feat: updated rules based on discussion

### DIFF
--- a/configs/@typescript-eslint/index.js
+++ b/configs/@typescript-eslint/index.js
@@ -23,7 +23,14 @@ module.exports = {
       "extendDefaults": true,
     },
   ],
-  "@typescript-eslint/naming-convention": "off",
+  "@typescript-eslint/naming-convention": [
+    "error", 
+    { 
+      "selector": "variable", 
+      "format": ["camelCase", "PascalCase", "UPPER_CASE"], 
+      "leadingUnderscore": "allow" 
+    }
+  ],
   "@typescript-eslint/consistent-type-assertions": ["error"],
   "@typescript-eslint/no-array-constructor": ["error"],
   "@typescript-eslint/no-empty-function": ['error', { 'allow': ['arrowFunctions'] }],

--- a/configs/eslint/index.js
+++ b/configs/eslint/index.js
@@ -43,14 +43,14 @@ module.exports = {
   "max-len": [
     "error",
     {
-      code: 120,
+      code: 200,
       tabWidth: 2,
       ignoreTemplateLiterals: true,
       ignoreStrings: true,
       ignoreComments: true
     }
   ],
-  "comma-dangle": ["error", "never"],
+  "comma-dangle": ["error", "always-multiline"], // not having a trailing comma results in unnecessary git changes
   "implicit-arrow-linebreak": ["off", "beside"],
   camelcase: [
     "off",
@@ -193,22 +193,7 @@ module.exports = {
       allowUnboundThis: true
     }
   ],
-  "prefer-destructuring": [
-    "error",
-    {
-      VariableDeclarator: {
-        array: false,
-        object: true
-      },
-      AssignmentExpression: {
-        array: true,
-        object: false
-      }
-    },
-    {
-      enforceForRenamedProperties: false
-    }
-  ],
+  "prefer-destructuring": ["off"], // adds unnecessary lines and removes context from code
   "prefer-numeric-literals": ["error"],
   "prefer-reflect": ["off"],
   "prefer-template": ["error"],

--- a/configs/import/index.js
+++ b/configs/import/index.js
@@ -6,7 +6,7 @@ module.exports = {
       caseSensitive: true
     }
   ],
-  "import/named": ["error"],
+  "import/named": ["off"], // not required for TS
   "import/default": ["off"],
   "import/namespace": ["off"],
   "import/export": ["error"],
@@ -66,7 +66,7 @@ module.exports = {
     }
   ],
   "import/newline-after-import": ["error"],
-  "import/prefer-default-export": ["error"],
+  "import/prefer-default-export": ["off"], // // adds unnecessary code change requirements when updating a 1 export module to multiple export and vice versa
   "import/no-restricted-paths": ["off"],
   "import/max-dependencies": [
     "off",

--- a/configs/react/index.js
+++ b/configs/react/index.js
@@ -260,12 +260,7 @@ module.exports = {
   ],
   "react/jsx-space-before-closing": ["off", "always"],
   "react/no-array-index-key": ["error"],
-  "react/require-default-props": [
-    "error",
-    {
-      forbidDefaultForRequired: true
-    }
-  ],
+  "react/require-default-props": ["off"], // not relevant to modern React with TS functional components
   "react/forbid-foreign-prop-types": [
     "off",
     {
@@ -297,7 +292,7 @@ module.exports = {
       children: "never"
     }
   ],
-  "react/destructuring-assignment": ["error", "always"],
+  "react/destructuring-assignment": ["off"], // adds unnecessary lines and removes context from code
   "react/no-access-state-in-setstate": ["error"],
   "react/button-has-type": [
     "error",


### PR DESCRIPTION
Updated the following rules

* `import/named`: error → off not required for typescript
* `comma-dangle`: never` → always-multiline no trailing comma results in unnecessary diff
* `prefer-destructuring`: error → off adds unnecessary lines and removes context from code
* `react/destructuring-assignment`: error → off same as above
* `react/require-default-props`: error → off not relevant to Typescript functional components
* `import/prefer-default-export`: error → off adds unnecessary code change when adding exports
* `max-len`: 120 → 200 most code bases here have longer lines
* `@typescript-eslint/naming-convention`: ["warn", { "selector": "variable", "format": ["camelCase", "PascalCase", "UPPER_CASE"], "leadingUnderscore": "allow" }] 

